### PR TITLE
feat: add marketing and social media design to areas if contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ There are plenty of ways to share your contribution with this project, and you d
 - Iconography
 - Mascot ideation/illustration
 - UI Kit
+- Marketing/Social Media design
 
 Issues in this repo are open to all who would like to give feedback and/or provide visual work.
 


### PR DESCRIPTION
As per @derberg's suggestion in the "Let's talk about contributing" live stream, a line was added in the README to show that you can also contribute to marketing/social media design requests.