### PR TITLE
feat: add initial iconography guidelines and starter set

### DIFF
--- a/brand-guidelines/README.md
+++ b/brand-guidelines/README.md
@@ -8,4 +8,5 @@ Looking to make a contribution to AsyncAPI that requires visual design? Before d
     - [Logo](./logo/README.md)
     - [Color](./color/README.md)
     - [Typography](./typography/README.md)
+    - [Iconography](./iconography/README.md)
     - [Branded Tools](./branded-tools/README.md)

--- a/brand-guidelines/iconography/README.md
+++ b/brand-guidelines/iconography/README.md
@@ -1,0 +1,57 @@
+# Iconography documentation and usage guidelines
+
+This guide defines a starting point for a unified AsyncAPI icon system that can be used across marketing surfaces and tooling UIs.
+
+## Goals
+
+- Keep icons visually consistent with the existing AsyncAPI brand mark and tooling logos.
+- Prefer simple geometric forms that stay readable at small sizes.
+- Make the set usable in both product interfaces and editorial/marketing layouts.
+
+## Core style rules
+
+- Use a `2px` stroke on a `24 x 24` grid.
+- Prefer rounded joins and rounded line caps.
+- Build icons from circles, straight segments, and soft radii rather than sharp ornamental detail.
+- Keep fills optional; default to outline-first icons.
+- Avoid mixing multiple stroke weights inside one icon.
+
+## Color usage
+
+- Default UI icon color: `#1B1130`
+- Accent / active color: `#19B5FE`
+- Inverse icon color on dark surfaces: `#FFFFFF`
+
+Icons should work in monochrome first. Accent fills should only be used to highlight one intentional focus area.
+
+## Categories
+
+- Platform concepts: event, channel, broker, schema
+- Product actions: search, generate, validate, inspect
+- Ecosystem markers: docs, community, integrations, automation
+
+## Asset structure
+
+- Store reusable source icons in `brand-guidelines/iconography/svg/`
+- Keep naming flat and descriptive: `asyncapi-icon_event.svg`
+- Export dark and light variants only when a single monochrome source is not sufficient
+
+## Starter set
+
+The initial seed set included here is intentionally small:
+
+- Event
+- Channel
+- Broker
+- Schema
+
+These icons are meant to establish the visual language before expanding the full library.
+
+## Contribution guidance
+
+- New icons should align to the same 24px grid and 2px stroke.
+- Reuse the same corner radius language before inventing new silhouettes.
+- If an icon needs a filled area to be understandable, keep the fill to one dominant shape.
+- Submit SVG exports with clean paths and without editor metadata when possible.
+
+[<-- Back to Brand Guidelines home](/brand-guidelines/README.md)

--- a/brand-guidelines/iconography/svg/asyncapi-icon_broker.svg
+++ b/brand-guidelines/iconography/svg/asyncapi-icon_broker.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="4" width="14" height="5" rx="2.5" stroke="#1B1130" stroke-width="2"/>
+  <rect x="5" y="15" width="14" height="5" rx="2.5" stroke="#1B1130" stroke-width="2"/>
+  <path d="M12 9V15" stroke="#1B1130" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="12" cy="12" r="2" fill="#19B5FE"/>
+</svg>

--- a/brand-guidelines/iconography/svg/asyncapi-icon_channel.svg
+++ b/brand-guidelines/iconography/svg/asyncapi-icon_channel.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="6" width="16" height="12" rx="4" stroke="#1B1130" stroke-width="2"/>
+  <path d="M7 12H17" stroke="#1B1130" stroke-width="2" stroke-linecap="round"/>
+  <path d="M10 9L7 12L10 15" stroke="#19B5FE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M14 9L17 12L14 15" stroke="#19B5FE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/brand-guidelines/iconography/svg/asyncapi-icon_event.svg
+++ b/brand-guidelines/iconography/svg/asyncapi-icon_event.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="7" cy="12" r="2.5" stroke="#1B1130" stroke-width="2"/>
+  <circle cx="17" cy="7" r="2.5" stroke="#1B1130" stroke-width="2"/>
+  <circle cx="17" cy="17" r="2.5" stroke="#1B1130" stroke-width="2"/>
+  <path d="M9.2 10.9L14.8 8.1" stroke="#1B1130" stroke-width="2" stroke-linecap="round"/>
+  <path d="M9.2 13.1L14.8 15.9" stroke="#1B1130" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/brand-guidelines/iconography/svg/asyncapi-icon_schema.svg
+++ b/brand-guidelines/iconography/svg/asyncapi-icon_schema.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 4H14L18 8V18C18 19.1046 17.1046 20 16 20H8C6.89543 20 6 19.1046 6 18V6C6 4.89543 6.89543 4 8 4Z" stroke="#1B1130" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M14 4V8H18" stroke="#1B1130" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M9 11H15" stroke="#19B5FE" stroke-width="2" stroke-linecap="round"/>
+  <path d="M9 15H13" stroke="#1B1130" stroke-width="2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Fixes #119

This is a first structured pass at a unified iconography system for AsyncAPI:
- add a dedicated iconography guideline page under the brand docs
- define shared grid, stroke, color, and contribution rules
- seed the system with four reusable SVG icons for core platform concepts: event, channel, broker, and schema
- link the new section from the main brand guideline index

This keeps the first PR intentionally small so the visual language can be reviewed before expanding the full icon library.
